### PR TITLE
flask 0.12.3 bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==6.7
 configobj==4.7.2
 decorator==3.4.0
 dominate==2.3.1
-Flask==0.12.3
+Flask==0.12.4
 Flask-Bootstrap==3.3.7.1
 Flask-Login==0.4.0
 Flask-Migrate==2.0.3


### PR DESCRIPTION
flask 0.12.3在`python manage.py db init`时候会出现
AttributeError: 'Blueprint' object has no attribute 'json_encoder'
参见 dpgaspar/Flask-AppBuilder#741